### PR TITLE
ignore metrics with no tags

### DIFF
--- a/kairos/client.go
+++ b/kairos/client.go
@@ -74,7 +74,7 @@ func (client HTTPClient) AddPoints(points []Point) error {
 
 	rsp, err := client.client.Do(req)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if rsp.StatusCode >= 300 {


### PR DESCRIPTION
we were getting entire batches rejected because of a single metric. Now we reject and track those